### PR TITLE
enhancement(ci): set lint exit code to 1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout=3m --issues-exit-code=0 ./...
+          args: --timeout=3m --issues-exit-code=1 ./...
           only-new-issues: true
 
   unit-tests:


### PR DESCRIPTION
# Description

This PR changes the linting exit code from 0 to 1, if new failures have been found.
