### PR TITLE
fix: load cache error rate

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func main() {
 				defer cf()
 				err := clnt.LoadCache(ctx)
 				if err != nil {
-					cacheLog.Error(err, "unable to load passbolt cache")
+					cacheLog.Error(err, "unable to load passbolt cache", "errorCounter", errorCounter)
 					if errorCounter > loadCacheErrorRetryCounterReLogin {
 						if errorCounter >= loadCacheErrorRetryCounterExit {
 							// we exit here, because we failed to load the cache 3 times in a row

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func main() {
 				defer cf()
 				err := clnt.LoadCache(ctx)
 				if err != nil {
-					cacheLog.Error(err, "unable to load passbolt cache", "errorCounter", errorCounter)
+					cacheLog.Error(err, "unable to update local passbolt cache", "errorCounter", errorCounter)
 					if errorCounter > loadCacheErrorRetryCounterReLogin {
 						if errorCounter >= loadCacheErrorRetryCounterExit {
 							// we exit here, because we failed to load the cache 3 times in a row

--- a/pkg/passbolt/passbolt.go
+++ b/pkg/passbolt/passbolt.go
@@ -140,3 +140,18 @@ func (c *Client) GetSecret(ctx context.Context, name string) (*PassboltSecretDef
 	}
 	return secret, nil
 }
+
+// ReLogin logs out of the passbolt client and logs in again.
+// This is useful if the session has expired.
+// This function should be called before any other function.
+func (c *Client) ReLogin(ctx context.Context) error {
+	err := c.Close(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to close passbolt client: %w", err)
+	}
+	err = c.passboltClient.Login(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to re-login to passbolt: %w", err)
+	}
+	return nil
+}

--- a/pkg/passbolt/passbolt_test.go
+++ b/pkg/passbolt/passbolt_test.go
@@ -467,3 +467,48 @@ func TestClient_GetSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_ReLogin(t *testing.T) {
+	type fields struct {
+		client *Client
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "re-login to passbolt",
+			fields: fields{
+				client: func() *Client {
+					clnt, err := NewClient(
+						context.Background(),
+						passboltURL,
+						passboltUsername,
+						passboltPassword,
+					)
+					if err != nil {
+						t.Errorf("failed to create passbolt client: %v", err)
+						return nil
+					}
+					return clnt
+				}(),
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fields.client.ReLogin(tt.args.ctx); (err != nil) != tt.wantErr {
+				t.Errorf("Client.ReLogin() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR fixes a problem with authentication against passbolt. If passbolt is unavailable for more than 10 minutes, we try to log in again. If unsuccessful, we immediately abort the process. If for some reason the passbolt client fails after another attempt, we abort the process as well.

## How Has This Been Tested?

- [x] ReLogin locally using go test ./...
- [ ] ...

**Test Configuration**:

- Kubernetes version: `1.25.3`
- Kubectl version: `v1.27.2`
- Node operation system: `Ubuntu 22.04`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
