### PR TITLE
fix: pin cert-manager to v1.11.0 to avoid incompatibilities

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -303,7 +303,8 @@ jobs:
             --namespace cert-manager \
             --create-namespace \
             --set installCRDs=true \
-            --set prometheus.enabled=false
+            --set prometheus.enabled=false \
+            --version v1.11.0
 
       - name: Deploy CRDs
         run: |


### PR DESCRIPTION
# Description

This PR pins the cert-manager version to v1.11.0 to avoid incompatibilities

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
