### PR TITLE
fix: add sleep before comparison of secret versions

### DIFF
--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -74,6 +74,7 @@ spec:
         field: uri
 EOF
 )"
+    sleep 5
 }
 
 # createPassboltSecretV1alpha2 <name>
@@ -105,6 +106,7 @@ spec:
         value: postgres://{{.Username}}@{{.URI}}/passbolt?sslmode=disable&password={{.Password}}&connect_timeout=10
 EOF
 )"
+    sleep 5
 }
 
 # createPassboltSecretV1alpha3 <name>
@@ -135,4 +137,5 @@ spec:
     foo: bar
 EOF
 )"
+    sleep 5
 }


### PR DESCRIPTION
# Description

e2etest version comparison of created secrets was done before the secrets have been created. A 'sleep 5' was added to ensure that creation of the secrets has been finished before running the test.

## How Has This Been Tested?

make test-e2e has been run locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
