### PR TITLE
chore: renamed package reference from v1alpha2 to passboltv1alpha2

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	passboltv1 "github.com/urbanmedia/passbolt-operator/api/v1"
-	"github.com/urbanmedia/passbolt-operator/api/v1alpha2"
 	passboltv1alpha2 "github.com/urbanmedia/passbolt-operator/api/v1alpha2"
 	passboltv1alpha3 "github.com/urbanmedia/passbolt-operator/api/v1alpha3"
 	"github.com/urbanmedia/passbolt-operator/internal/controller"
@@ -149,8 +148,8 @@ func main() {
 	}
 
 	// initialize passbolt client cache hit functions
-	v1alpha2.GetSecretID = clnt.GetSecretID
-	v1alpha2.GetSecretName = clnt.GetSecretName
+	passboltv1alpha2.GetSecretID = clnt.GetSecretID
+	passboltv1alpha2.GetSecretName = clnt.GetSecretName
 
 	// initial cache load
 	err = clnt.LoadCache(ctx)


### PR DESCRIPTION
# Description

Use PassboltSecret v1 for internal object handling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
