### PR TITLE
chore: use go 1.22 in CI workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  go_version: 1.21
+  go_version: 1.22
 
 jobs:
   release:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ on:
       - "!dependabot/**"
 
 env:
-  go_version: '1.21'
+  go_version: '1.22'
   artifact_name: passbolt-operator
   artifact_bin_name: kubebuilder
   IMG: tagesspiegel/passbolt-operator:dev


### PR DESCRIPTION
# Description

Use latest available Go version.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
