### PR TITLE
docs: removed deprecated name field from v1 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ spec:
   secretType: Opaque
   passboltSecrets:
     s3_access_key:
-      name: EXAMPLE_APP
+      id: 00000000-0000-0000-0000-000000000000
       field: username
     dsn:
-      name: EXAMPLE_APP
+      id: 00000000-0000-0000-0000-000000000000
       value: postgres://{{ .Username }}@{{ .URI }}/mydb?sslmode=disable&password={{ .Password }}
   plainTextFields:
     key: value


### PR DESCRIPTION
# Description

In version v1alpha3 and v1, secrets can not be referenced with "name" any more.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
