### PR TITLE
Remove code owner from CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @urbanmedia/platform @urbanmedia/unitb-platform
+* @urbanmedia/platform 


### PR DESCRIPTION
This PR removes @urbanmedia/unitb-platform from the CODEOWNERS file.